### PR TITLE
Add force flag for logging config

### DIFF
--- a/src/fairseq2/utils/logging.py
+++ b/src/fairseq2/utils/logging.py
@@ -18,6 +18,7 @@ def setup_logging(
     log_file: Optional[Path] = None,
     debug: bool = False,
     utc_time: bool = False,
+    force: bool = False,
 ) -> None:
     """Set up logging for a training or eval job.
 
@@ -28,6 +29,8 @@ def setup_logging(
         If ``True``, sets the log level to `DEBUG`; otherwise, to `INFO`.
     :param utc_time:
         If ``True``, logs dates and times in UTC.
+    :param force:
+        If ``True``, overwrite existing logging `basicConfig`
     """
     rank = get_global_rank()
 
@@ -57,7 +60,7 @@ def setup_logging(
     datefmt = "%Y-%m-%d %H:%M:%S"
 
     logging.basicConfig(
-        level=DEBUG if debug else INFO, handlers=handlers, format=fmt, datefmt=datefmt
+        level=DEBUG if debug else INFO, handlers=handlers, format=fmt, datefmt=datefmt, force=force
     )
 
     if utc_time:


### PR DESCRIPTION
**What does this PR do?**
Logging config is not applied if the config has already been defined in a previous import. This makes `setup_logging` useless. The `force` flag can be added to the basicConfig to overwrite what has been defined before.


**Does your PR introduce any breaking changes? If yes, please list them:**
I don't think it will break anything. Works locally. Default value set to previous behavior (False).

**Check list:**
- [ ] Was the content of this PR **discussed and approved** via a GitHub issue? (no need for typos or documentation improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairseq2/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/facebookresearch/fairseq2/blob/main/CHANGELOG.md)**? (no need for typos, documentation, or minor internal changes)
